### PR TITLE
Fix relative theme directory

### DIFF
--- a/src/verbs/generate.js
+++ b/src/verbs/generate.js
@@ -242,9 +242,8 @@ Implementation of the 'generate' verb for HackMyResume.
   Verify the specified theme name/path.
   */
   function verify_theme( themeNameOrPath ) {
-    var tFolder = PATH.resolve(
-      __dirname,
-      '../../node_modules/fresh-themes/themes',
+    var tFolder = PATH.join(
+      parsePath ( require.resolve('fresh-themes') ).dirname,
       themeNameOrPath
     );
     var exists = require('path-exists').sync;


### PR DESCRIPTION
The theme directory assumes it was a child of the HackMyResume module, but NPM3 will actually flatten this out. Following the same logic that the template-generator uses, find the path to the themes using NPMs require method.