### PR TITLE
formatDate template helper error handling and fallback

### DIFF
--- a/src/eng/generic-helpers.js
+++ b/src/eng/generic-helpers.js
@@ -28,10 +28,7 @@ Generic template helper definitions for HackMyResume / FluentCV.
     formatDate: function(datetime, format, fallback) {
       if (moment) {
         var momentDate = moment( datetime );
-
-        if (momentDate.isValid()) {
-          return moment.format(format);
-        }
+        if (momentDate.isValid()) return momentDate.format(format);
       }
 
       return datetime || (typeof fallback == 'string' ? fallback : (fallback === true ? 'Present' : null));

--- a/src/eng/generic-helpers.js
+++ b/src/eng/generic-helpers.js
@@ -21,10 +21,20 @@ Generic template helper definitions for HackMyResume / FluentCV.
 
     /**
     Convert the input date to a specified format through Moment.js.
+    If date is invalid, will return the time provided by the user, 
+    or default to the fallback param or 'Present' if that is set to true
     @method formatDate
     */
-    formatDate: function(datetime, format) {
-      return moment ? moment( datetime ).format( format ) : datetime;
+    formatDate: function(datetime, format, fallback) {
+      if (moment) {
+        var momentDate = moment( datetime );
+
+        if (momentDate.isValid()) {
+          return moment.format(format);
+        }
+      }
+
+      return datetime || (typeof fallback == 'string' ? fallback : (fallback === true ? 'Present' : null));
     },
 
     /**


### PR DESCRIPTION
See fluentdesk/fresh-themes#23 and #84

Improved the way the `formatDate` template helper behaves so that it properly checks to make sure the inputted timestamp is valid. If it's not, it will just use the provided value from the user or use a `fallback`. If the `fallback` is a string, it will use that string. If it is `true`, it will default to 'Present'.  This should make it as flexible as possible and handles errors with invalid dates being entered as well. 