### PR TITLE
load theme partials for non html and doc

### DIFF
--- a/src/eng/handlebars-generator.js
+++ b/src/eng/handlebars-generator.js
@@ -61,30 +61,31 @@ Definition of the HandlebarsGenerator class.
 
 
   function registerPartials(format, theme) {
-    if( format !== 'html' && format != 'doc' )
-      return;
+    if( format === 'html' || format === 'doc' ) {
 
-    // Locate the global partials folder
-    var partialsFolder = PATH.join(
-      parsePath( require.resolve('fresh-themes') ).dirname,
-      '/partials/',
-      format
-    );
+      // Locate the global partials folder
+      var partialsFolder = PATH.join(
+        parsePath( require.resolve('fresh-themes') ).dirname,
+        '/partials/',
+        format
+      );
 
-    // Register global partials in the /partials folder
-    // TODO: Only do this once per HMR invocation.
-    _.each( READFILES( partialsFolder, function(error){ }), function( el ) {
-      var pathInfo = parsePath( el );
-      var name = SLASH( PATH.relative( partialsFolder, el )
-        .replace(/\.html$|\.xml$/, '') );
-      if( pathInfo.dirname.endsWith('section') ) {
-        name = SLASH(name.replace(/\.html$|\.xml$/, ''));
-      }
-      var tplData = FS.readFileSync( el, 'utf8' );
-      var compiledTemplate = HANDLEBARS.compile( tplData );
-      HANDLEBARS.registerPartial( name, compiledTemplate );
-      theme.partialsInitialized = true;
-    });
+      // Register global partials in the /partials folder
+      // TODO: Only do this once per HMR invocation.
+      _.each( READFILES( partialsFolder, function(error){ }), function( el ) {
+        var pathInfo = parsePath( el );
+        var name = SLASH( PATH.relative( partialsFolder, el )
+          .replace(/\.html$|\.xml$/, '') );
+        if( pathInfo.dirname.endsWith('section') ) {
+          name = SLASH(name.replace(/\.html$|\.xml$/, ''));
+        }
+        var tplData = FS.readFileSync( el, 'utf8' );
+        var compiledTemplate = HANDLEBARS.compile( tplData );
+        HANDLEBARS.registerPartial( name, compiledTemplate );
+        theme.partialsInitialized = true;
+      });
+
+    }
 
     // Register theme-specific partials
     _.each( theme.partials, function( el ) {


### PR DESCRIPTION
For my [custom theme](https://github.com/aruberto/resume/tree/master/template), I am using partials to share common html between the html and pdf templates.

This was working fine in HackMyResume@1.3.1 but pdf generation fails due to not being able to find my partials when I updated to 1.4.1 

I noticed following was added to start of registerPartials() method:

```
if( format !== 'html' && format != 'doc' )
  return;
```

I'm guessing this was added since global partials only exist in https://github.com/fluentdesk/fresh-themes/tree/master/partials for html and doc.

However the condition prevents theme partials from registering when output is not html or doc (in my case pdf).

This pull requests changes the logic so that loading global partials only occurs for html and doc output while theme partials are always loaded.