### PR TITLE
Update fresh-resume-starter dependancy to 0.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "extend": "^3.0.0",
     "fresca": "~0.6.0",
     "fresh-jrs-converter": "^0.2.2",
-    "fresh-resume-starter": "^0.2.2",
+    "fresh-resume-starter": "^0.3.0",
     "fresh-themes": "^0.15.1-beta",
     "fs-extra": "^0.26.4",
     "handlebars": "^4.0.5",


### PR DESCRIPTION
Fixes issue hacksalot/HackMyResume#165.

I performed the automated tests and did not see any new failures than those that already occur in my setup with the current dev and master heads (see issues hacksalot/HackMyResume#181, hacksalot/HackMyResume#182).