### PR TITLE
Add option to pass wkhtmltopdf options. Fix #176.

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,10 @@ The options file can contain any documented HackMyResume option, including
   "sectionTitles": {
     "employment": "Work"
   }
+  // Change wkhtmltopdf margins
+  "wkhtmltopdf": {
+    "margin-top": "20mm"
+  }
 }
 ```
 

--- a/dist/generators/html-pdf-cli-generator.js
+++ b/dist/generators/html-pdf-cli-generator.js
@@ -52,7 +52,7 @@ Definition of the HtmlPdfCLIGenerator class.
       }
       if (_.has(engines, safe_eng)) {
         this.errHandler = info.opts.errHandler;
-        engines[safe_eng].call(this, info.mk, info.outputFile, this.onError);
+        engines[safe_eng].call(this, info.mk, info.outputFile, info.opts, this.onError);
         return null;
       }
     };
@@ -86,11 +86,19 @@ Definition of the HtmlPdfCLIGenerator class.
     TODO: If HTML generation has run, reuse that output
     TODO: Local web server to ease wkhtmltopdf rendering
      */
-    wkhtmltopdf: function(markup, fOut, on_error) {
-      var tempFile;
+    wkhtmltopdf: function(markup, fOut, opts, on_error) {
+      var tempFile, wkhtmltopdf_args, wkhtmltopdf_options;
       tempFile = fOut.replace(/\.pdf$/i, '.pdf.html');
       FS.writeFileSync(tempFile, markup, 'utf8');
-      SPAWN('wkhtmltopdf', [tempFile, fOut], false, on_error, this);
+      wkhtmltopdf_options = _.extend({
+        'margin-bottom': '10mm',
+        'margin-top': '10mm'
+      }, opts.wkhtmltopdf);
+      wkhtmltopdf_options = _.flatten(_.map(wkhtmltopdf_options, function(v, k) {
+        return ['--' + k, v];
+      }));
+      wkhtmltopdf_args = wkhtmltopdf_options.concat([tempFile, fOut]);
+      SPAWN('wkhtmltopdf', wkhtmltopdf_args, false, on_error, this);
     },
 
     /**
@@ -100,7 +108,7 @@ Definition of the HtmlPdfCLIGenerator class.
     TODO: If HTML generation has run, reuse that output
     TODO: Local web server to ease Phantom rendering
      */
-    phantomjs: function(markup, fOut, on_error) {
+    phantomjs: function(markup, fOut, opts, on_error) {
       var destPath, scriptPath, sourcePath, tempFile;
       tempFile = fOut.replace(/\.pdf$/i, '.pdf.html');
       FS.writeFileSync(tempFile, markup, 'utf8');

--- a/dist/verbs/build.js
+++ b/dist/verbs/build.js
@@ -242,6 +242,7 @@ Implementation of the 'build' verb for HackMyResume.
     _opts.noTips = opts.noTips;
     _opts.debug = opts.debug;
     _opts.sort = opts.sort;
+    _opts.wkhtmltopdf = opts.wkhtmltopdf;
     that = this;
     _opts.onTransform = function(info) {
       that.stat(HMEVENT.afterTransform, info);

--- a/src/verbs/build.coffee
+++ b/src/verbs/build.coffee
@@ -176,6 +176,7 @@ _prep = ( src, dst, opts ) ->
   _opts.noTips = opts.noTips
   _opts.debug = opts.debug
   _opts.sort = opts.sort
+  _opts.wkhtmltopdf = opts.wkhtmltopdf
   that = @
 
   # Set up callbacks for internal generators


### PR DESCRIPTION
It seems that some time in the last couple years wkhtmltopdf's default
margins were changed from '10mm' to zero. As an alternative to #177,
this PR adds an option to pass in arbitrary wkhtmltopdf long arguments
and sets the default top and bottom margin to '10mm'.