### PR TITLE
Register handlebars helpers in themes. Fix #158.

### DIFF
--- a/dist/core/fresh-theme.js
+++ b/dist/core/fresh-theme.js
@@ -95,7 +95,7 @@ Definition of the FRESHTheme class.
   /* Load and parse theme source files. */
 
   _load = function(formatsHash) {
-    var copyOnly, fmts, major, that, tplFolder;
+    var copyOnly, fmts, jsFiles, major, that, tplFolder;
     that = this;
     major = false;
     tplFolder = PATH.join(this.folder, 'src');
@@ -123,6 +123,12 @@ Definition of the FRESHTheme class.
           };
         }
       }
+    });
+    jsFiles = fmts.filter(function(fmt) {
+      return fmt && (fmt.ext === 'js');
+    });
+    this.jsFiles = jsFiles.map(function(jsf) {
+      return jsf['path'];
     });
     return formatsHash;
   };

--- a/dist/helpers/handlebars-helpers.js
+++ b/dist/helpers/handlebars-helpers.js
@@ -23,7 +23,7 @@ Template helper definitions for Handlebars.
    */
 
   module.exports = function(theme, opts) {
-    var wrappedHelpers;
+    var i, len, ref, themeHelpers, wrappedHelpers;
     helpers.theme = theme;
     helpers.opts = opts;
     helpers.type = 'handlebars';
@@ -41,6 +41,11 @@ Template helper definitions for Handlebars.
     }, this);
     HANDLEBARS.registerHelper(wrappedHelpers);
     HANDLEBARS.registerHelper(blockHelpers);
+    ref = theme.jsFiles;
+    for (i = 0, len = ref.length; i < len; i++) {
+      themeHelpers = ref[i];
+      HANDLEBARS.registerHelper(require(themeHelpers));
+    }
   };
 
 }).call(this);

--- a/src/core/fresh-theme.coffee
+++ b/src/core/fresh-theme.coffee
@@ -115,8 +115,12 @@ _load = (formatsHash) ->
         # Found a CSS file without an HTML file in a theme that inherits
         # from another theme. This is the override CSS file.
         that.overrides = { file: cssf.path, data: cssf.data }
-  formatsHash
 
+  # Now, save all the javascript file paths to a theme property.
+  jsFiles = fmts.filter (fmt) -> fmt and (fmt.ext == 'js')
+  @.jsFiles = jsFiles.map (jsf) -> jsf['path']
+
+  formatsHash
 
 
 ### Load a single theme file. ###

--- a/src/helpers/handlebars-helpers.coffee
+++ b/src/helpers/handlebars-helpers.coffee
@@ -30,7 +30,9 @@ module.exports = ( theme, opts ) ->
         func.apply @, args
     hVal
   , @
-  
+
   HANDLEBARS.registerHelper wrappedHelpers
   HANDLEBARS.registerHelper blockHelpers
+  for themeHelpers in theme.jsFiles
+    HANDLEBARS.registerHelper require themeHelpers
   return


### PR DESCRIPTION
Try to register all javascript files found in themes as handlebars
helpers.

Note that, unlike all other theme files currently, format directories
are ignored. I don't think there's a use case for format-specific
helpers, and this gives theme developers the flexibility to put them
either in top level files or organize them in subdirectories however
they see fit.

Note also that the theme format seems to be primarily documented in
<https://github.com/fresh-standard/fresh-themes>. This newly recognized
theme file type should be documented there should this branch be merged.