### PR TITLE
Mark options file example JSON and remove comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,11 +482,9 @@ hackmyresume BUILD resume.json -o path/to/options.json
 The options file can contain any documented HackMyResume option, including
 `theme`, `silent`, `debug`, `pdf`, `css`, and other settings.
 
-```javascript
+```json
 {
-  // Set the default theme to "compact"
   "theme": "compact",
-  // Change the "employment" section title text to "Work"
   "sectionTitles": {
     "employment": "Work"
   }


### PR DESCRIPTION
The options file is JSON, not JavaScript, and JSON does not allow
comments. An options file with comments as shown in the current
example in README.md will fail to load.

This commit removes the comments. They do not seem important enough to
place them elsewhere.