### PR TITLE
Update generic-helpers.js

### DIFF
--- a/src/helpers/generic-helpers.js
+++ b/src/helpers/generic-helpers.js
@@ -383,7 +383,7 @@ var GenericHelpers = (module.exports = {
   wpml( txt, inline ) {
     if (!txt) { return ''; }
     inline = (inline && !inline.hash) || false;
-    txt = XML(txt.trim());
+    txt = XML(txt.trim(), '&');
     txt = inline ? MD(txt).replace(/^\s*<p>|<\/p>\s*$/gi, '') : MD(txt);
     txt = H2W( txt );
     return txt;


### PR DESCRIPTION
I noticed when converting to word, it doesn't handle certain HTML entities well. It ends up displaying "&amp;quot;" and so on.

Figured out by the time it reaches the wpml (which converts to WordProcessingML) function, the string was already escaped (although I don't know how it does that). So if you put quote (") in your resume JSON (e.g. a writing summary), it'll look like &amp;quot; at the START of the wpml function.

The problem is in line 386, it uses xml-escape to escape it again. So it'll end up as "&amp;amp;quot;", which in the end rendered on the document as "&amp;quot;".

As such, I propose a change to ignore "&amp;" when using xml-escape.