### PR TITLE
Fix the option --no-escape

### DIFF
--- a/src/renderers/handlebars-generator.js
+++ b/src/renderers/handlebars-generator.js
@@ -38,7 +38,7 @@ module.exports = {
       template = HANDLEBARS.compile(tpl, {
         strict: false,
         assumeObjects: false,
-        noEscape: data.opts.noescape
+        noEscape: !data.opts.escape
       }
       );
       return template(data);

--- a/src/verbs/build.js
+++ b/src/verbs/build.js
@@ -194,7 +194,7 @@ var _prep = function( src, dst, opts ) {
   _opts.theme = (opts.theme && opts.theme.toLowerCase().trim()) || 'modern';
   _opts.prettify = opts.prettify === true;
   _opts.private = opts.private === true;
-  _opts.noescape = opts.noescape === true;
+  _opts.noescape = opts.escape === false;
   _opts.css = opts.css;
   _opts.pdf = opts.pdf;
   _opts.wrap = opts.wrap || 60;

--- a/src/verbs/build.js
+++ b/src/verbs/build.js
@@ -194,7 +194,7 @@ var _prep = function( src, dst, opts ) {
   _opts.theme = (opts.theme && opts.theme.toLowerCase().trim()) || 'modern';
   _opts.prettify = opts.prettify === true;
   _opts.private = opts.private === true;
-  _opts.noescape = opts.escape === false;
+  _opts.escape = opts.escape === true;
   _opts.css = opts.css;
   _opts.pdf = opts.pdf;
   _opts.wrap = opts.wrap || 60;


### PR DESCRIPTION
Fixes #219

I verified the correctness by running the tests with `grunt test`. The output shows the same 11 test failures as when run on `dev`. Moreover, I tested the fixed functionality manually by generating a HTML resume with an ampersand (`&`) character in a job title.