### PR TITLE
Add wkhtmltopdf flag: enable local file access

### DIFF
--- a/src/generators/html-pdf-cli-generator.js
+++ b/src/generators/html-pdf-cli-generator.js
@@ -80,7 +80,7 @@ var engines = {
     // Prepare wkhtmltopdf arguments.
     let wkopts = _.extend({'margin-top': '10mm', 'margin-bottom': '10mm'}, opts.wkhtmltopdf);
     wkopts = _.flatten(_.map(wkopts, (v, k) => [`--${k}`, v]));
-    const wkargs = wkopts.concat([ tempFile, fOut  ]);
+    const wkargs = wkopts.concat(['--enable-local-file-access', tempFile, fOut  ]);
 
     SPAWN('wkhtmltopdf', wkargs , false, on_error, this);
   },


### PR DESCRIPTION
When generating PDFs with the wkhtmltopdf option I noticed, that local images don't end up in the generated PDF. After some googling I found that a flag is need now to enable local file access in wkhtmltopdf: https://stackoverflow.com/a/62315247

I'm currently using wkhtmltopdf version 0.12.6